### PR TITLE
Support platform specific INPUTDIR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.cache
 *.sublime-project
+*.sublime-workspace

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -3,6 +3,7 @@
     { "id": "SublimePelican", "caption": "SublimePelican", "children": [
         { "caption": "Insert Category", "command": "pelican_insert_category" },
         { "caption": "Insert Tag", "command": "pelican_insert_tag" },
+        { "caption": "Insert Link to Post", "command": "pelican_link_to_post" },
         { "caption": "-" },
         { "caption": "New Article (Markdown)", "command": "pelican_new_markdown" },
         { "caption": "New Article (reStructuredText)", "command": "pelican_new_restructuredtext" },

--- a/Pelican.py
+++ b/Pelican.py
@@ -388,9 +388,13 @@ def isPelicanArticle(view):
             view, "use_input_folder_in_makefile", True)
         if use_input_folder_in_makefile:
             makefile_params = parse_makefile(view.window())
-            if makefile_params and "INPUTDIR" in makefile_params:
-                filepath_filter = makefile_params[
-                    'INPUTDIR'] + "/" + default_filter
+            inputdir = None
+            if makefile_params and "INPUTDIR_"+sublime.platform() in makefile_params:
+                inputdir = makefile_params["INPUTDIR_"+sublime.platform()]
+            elif makefile_params and "INPUTDIR" in makefile_params:
+                inputdir = makefile_params["INPUTDIR"]
+            if inputdir is not None:
+                filepath_filter = inputdir + "/" + default_filter
 
         if re.search(filepath_filter, view.file_name()):
             return True
@@ -500,8 +504,12 @@ def get_article_paths(window):
     # load INPUTDIR
     inputdir = None
     makefile_params = parse_makefile(window)
-    if makefile_params and "INPUTDIR" in makefile_params:
-        inputdir = makefile_params['INPUTDIR']
+    if makefile_params and "INPUTDIR_"+sublime.platform() in makefile_params:
+        inputdir = makefile_params["INPUTDIR_"+sublime.platform()]
+        print(inputdir)
+    elif makefile_params and "INPUTDIR" in makefile_params:
+        inputdir = makefile_params["INPUTDIR"]
+        print(inputdir)
     else:
         return []
 

--- a/Pelican.py
+++ b/Pelican.py
@@ -506,10 +506,8 @@ def get_article_paths(window):
     makefile_params = parse_makefile(window)
     if makefile_params and "INPUTDIR_"+sublime.platform() in makefile_params:
         inputdir = makefile_params["INPUTDIR_"+sublime.platform()]
-        print(inputdir)
     elif makefile_params and "INPUTDIR" in makefile_params:
         inputdir = makefile_params["INPUTDIR"]
-        print(inputdir)
     else:
         return []
 

--- a/Pelican.sublime-commands
+++ b/Pelican.sublime-commands
@@ -1,5 +1,6 @@
 [
     { "caption": "Pelican: Insert Metadata", "command": "pelican_insert_metadata" },
+    { "caption": "Insert Link to Post", "command": "pelican_link_to_post" },
     { "caption": "Pelican: New Article (Markdown)", "command": "pelican_new_markdown" },
     { "caption": "Pelican: New Article (reStructuredText)", "command": "pelican_new_restructuredtext" },
     { "caption": "Pelican: Select Article Metadata", "command": "pelican_select_metadata" },

--- a/Pelican.sublime-commands
+++ b/Pelican.sublime-commands
@@ -6,5 +6,6 @@
     { "caption": "Pelican: Update Article Date", "command": "pelican_update_date" },
     { "caption": "Pelican: Update Slug using Title", "command": "pelican_generate_slug" },
     { "caption": "Pelican: Insert Category", "command": "pelican_insert_category" },
-    { "caption": "Pelican: Insert Tag", "command": "pelican_insert_tag" }
+    { "caption": "Pelican: Insert Tag", "command": "pelican_insert_tag" },
+    { "caption": "Pelican: Move Article to Contents", "command": "pelican_move_post_to_contents" }
 ]

--- a/Pelican.sublime-settings
+++ b/Pelican.sublime-settings
@@ -1,4 +1,10 @@
 {
+  // ====================
+  // Force the blog paths
+  // ====================
+  "blog_path_Windows": "C:\\Users\\jmartin\\Dropbox\\secondcrack\\minorthoughts",
+  "blog_path_Darwin": "/Users/jmartin/Dropbox/secondcrack/minorthoughts",
+
   // ===============
   // Slug generation
   // ===============

--- a/lib/moveToPosts.py
+++ b/lib/moveToPosts.py
@@ -39,11 +39,8 @@ def getMoveInfo(file):
 		if not os.path.isdir(folder):
 			raise
 
-	# Create the sequence number
-	sequence = len(glob(os.path.join(folder,datePrefix+"*.md"))) + 1
-
-	# File format: YYYYMMDD-seq-name
-	newFile = os.path.join( folder, "%s-%s-%s" % (datePrefix,sequence,fileName) )
+	# File format: YYYYMMDD-name
+	newFile = os.path.join( folder, "%s-%s" % (datePrefix,fileName) )
 
 	return (fullPath,newFile)
 

--- a/lib/moveToPosts.py
+++ b/lib/moveToPosts.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import os, os.path, argparse, platform
+from datetime import date
+from glob import glob
+
+__all__ = [
+	"getMoveInfo"
+]
+
+def getMoveInfo(file):
+	INPUTS = {
+		"Windows": "C:\\Users\\jmartin\\Dropbox\\secondcrack\\minorthoughts",
+		"Darwin": "/Users/jmartin/Dropbox/secondcrack/minorthoughts"
+	}
+
+	root = None
+	if platform.system() in INPUTS:
+		root = INPUTS[platform.system()]
+	if root is None:
+		print ("Where am I? I don't know where to move %s for you." % args.file)
+		return
+	
+	fullPath = os.path.abspath(file)
+	fileName = os.path.basename(fullPath)
+	
+	today = date.today()
+	yearName = today.strftime("%Y")
+	monthName = today.strftime("%m")
+	datePrefix = today.strftime("%Y%m%d")
+
+	# Construct the destination folder: content/posts/YYYY/MM
+	folder = os.path.join(root,"content","posts",yearName,monthName)
+
+	# Check if the destination exists, create it if not
+	try:
+		os.makedirs(folder)
+	except OSError:
+		if not os.path.isdir(folder):
+			raise
+
+	# Create the sequence number
+	sequence = len(glob(os.path.join(folder,datePrefix+"*.md"))) + 1
+
+	# File format: YYYYMMDD-seq-name
+	newFile = os.path.join( folder, "%s-%s-%s" % (datePrefix,sequence,fileName) )
+
+	return (fullPath,newFile)
+
+if __name__=="__main__":
+	parser = argparse.ArgumentParser(description="Move a file into the content directory with an appropriate name.")
+	parser.add_argument("file")
+
+	# Go
+	args = parser.parse_args()
+
+	(fullPath,newFile) = getMoveInfo(args.file)
+
+	try:
+		os.rename(fullPath,newFile)
+	except OSError as err:
+		print("Error: %s" % err.strerror)
+	else:
+		print("Moved %s to %s" % (fullPath,newFile))


### PR DESCRIPTION
I wrote blog posts on both my Mac (main computer) and Windows desktop (at the office). I need a different INPUTDIR for each, due to the different folder structures on the two computers. This change allows you to create an INPUTDIR_osx, INPUTDIR_windows, and (presumably) INPUTDIR_linux setting in the Makefile, to have a different folder for each platform. If those settings don't exist, it will fall back to the default INPUTDIR.