### PR TITLE
Fix parsing of Pelican Makefile inside parse_makefile() method

### DIFF
--- a/Pelican.py
+++ b/Pelican.py
@@ -470,27 +470,25 @@ def parse_makefile(window):
         return None
 
     # parse parameters in Makefile
-    regex = re.compile("(\S+)=(.*)")
-    makefile_content = ""
+    origin_makefile_params = []
     with open(makefile_path, 'r') as f:
-        makefile_content = f.read()
+        for line in f.readlines():
+            m = re.match(r'^(\S+)=(.*)', line)
+            if m:
+                origin_makefile_params.append((m.group(1), m.group(2)))
 
-    if len(makefile_content) > 0:
-        origin_makefile_params = []
-        origin_makefile_params = regex.findall(makefile_content)
+    if len(origin_makefile_params) > 0:
 
-        if len(origin_makefile_params) > 0:
+        makefile_params = {"CURDIR": makefile_dir}
 
-            makefile_params = {"CURDIR": makefile_dir}
+        for (key, value) in origin_makefile_params:
+            if not key in makefile_params:
+                # replace "$(var)" to "%(var)s"
+                value = re.sub(r"\$\((\S+)\)", r"%(\1)s", value)
 
-            for (key, value) in origin_makefile_params:
-                if not key in makefile_params:
-                    # replace "$(var)" to "%(var)s"
-                    value = re.sub(r"\$\((\S+)\)", r"%(\1)s", value)
+                makefile_params[key] = value % makefile_params
 
-                    makefile_params[key] = value % makefile_params
-
-            return makefile_params
+        return makefile_params
     return None
 
 


### PR DESCRIPTION
Hello,

I use pelican 3.6.3, when I try to generate the application with `pelican-quickstart` command I get auto generated  Makefile inside application directory. The Makefile looks like this https://gist.github.com/Drey/769d38b4ae509fde76b9, error occurs when `parse_makefile()` trying to parse the Makefile:

```
reloading plugin Pelican.Pelican
Traceback (most recent call last):
  File "/Applications/Sublime Text.app/Contents/MacOS/sublime_plugin.py", line 556, in run_
    return self.run(edit)
  File "/Users/user/Library/Application Support/Sublime Text 3/Packages/Pelican/Pelican.py", line 280, in run
    articles_paths = get_article_paths(window=self.view.window())
  File "/Users/user/Library/Application Support/Sublime Text 3/Packages/Pelican/Pelican.py", line 612, in get_article_paths
    makefile_params = parse_makefile(window)
  File "/Users/user/Library/Application Support/Sublime Text 3/Packages/Pelican/Pelican.py", line 601, in parse_makefile
    makefile_params[key] = value % makefile_params
KeyError: 'SERVER'
```

It takes a place by reason of incorrect regexp for parse Makefile. Inside Makefile exists help block with comments, one of them processes like Makefile params:

```
...
@echo '   make serve-global [SERVER=0.0.0.0]  serve (as root) to $(SERVER):80    '
...
```
