### PR TITLE
[Fix] #6 #30

### DIFF
--- a/Pelican.py
+++ b/Pelican.py
@@ -42,10 +42,6 @@ class PelicanUpdateModifiedDateCommand(sublime_plugin.TextCommand):
 
         new_datestr_region = sublime.Region(
             date_region.end(), self.view.line(date_region).end())
-        self.view.sel().clear()
-        self.view.sel().add(new_datestr_region)
-
-        self.view.show(new_datestr_region)
 
 
 class PelicanGenerateSlugCommand(sublime_plugin.TextCommand):

--- a/Pelican.py
+++ b/Pelican.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+
 import codecs
 import datetime
 import os
@@ -27,10 +28,10 @@ default_filter = '.*\\.(md|markdown|mkd|rst)$'
 pelican_article_views = []
 
 
-class PelicanUpdateDateCommand(sublime_plugin.TextCommand):
+class PelicanUpdateModifiedDateCommand(sublime_plugin.TextCommand):
 
     def run(self, edit):
-        date_region = self.view.find(':?date:\s*', 0, sublime.IGNORECASE)
+        date_region = self.view.find(':?modified:\s*', 0, sublime.IGNORECASE)
         if not date_region:
             return
 
@@ -78,7 +79,8 @@ class PelicanGenerateSlugCommand(sublime_plugin.TextCommand):
 
             pelican_slug_template_result = normalize_line_endings(
                 self.view, pelican_slug_template[meta_type])
-            slug_region = self.view.find(':?slug:.+\s*', 0, sublime.IGNORECASE)
+            slug_region = self.view.find(
+                ':?slug:.+\s*', 0, sublime.IGNORECASE)
             if slug_region:
                 self.view.replace(
                     edit, slug_region, pelican_slug_template_result % slug)
@@ -142,7 +144,8 @@ class PelicanInsertMetadataCommand(sublime_plugin.TextCommand):
         if len(metadata_regions) > 0:
             for region in metadata_regions:
                 metadata_str = self.view.substr(region)
-                metadata_str = normalize_article_metadata_case(metadata_str)[0]
+                metadata_str = normalize_article_metadata_case(metadata_str)[
+                    0]
                 regex = re.compile(":?(\w+):(.*)")
                 find_all = regex.findall(metadata_str)
                 if len(find_all) > 0:
@@ -165,6 +168,22 @@ class PelicanInsertMetadataCommand(sublime_plugin.TextCommand):
         metadata_key_date = "Date"
         for key in metadata.keys():
             if key.lower() == "date":
+                metadata_key_date = key
+        if metadata[metadata_key_date] is "":
+            metadata[metadata_key_date] = strDateNow()
+
+        article_metadata_template = normalize_line_endings(
+            self.view, "\n".join(article_metadata_template_lines))
+        article_metadata_str = article_metadata_template % metadata
+        if len(metadata_regions) > 0:
+            self.view.replace(edit, old_metadata_region, article_metadata_str)
+        else:
+            self.view.insert(edit, 0, article_metadata_str)
+
+        # initialize modified field if it's empty
+        metadata_key_date = "Modified"
+        for key in metadata.keys():
+            if key.lower() == "modified":
                 metadata_key_date = key
         if metadata[metadata_key_date] is "":
             metadata[metadata_key_date] = strDateNow()
@@ -382,7 +401,8 @@ def isPelicanArticle(view):
         return True
 
     if view.file_name():
-        filepath_filter = load_setting(view, "filepath_filter", default_filter)
+        filepath_filter = load_setting(
+            view, "filepath_filter", default_filter)
 
         use_input_folder_in_makefile = load_setting(
             view, "use_input_folder_in_makefile", True)
@@ -411,7 +431,8 @@ def load_setting(view, setting_name, default_value):
 
     global_settings = sublime.load_settings("Pelican.sublime-settings")
 
-    return view.settings().get(setting_name, global_settings.get(setting_name, default_value))
+    return view.settings().get(
+        setting_name, global_settings.get(setting_name, default_value))
 
 
 def normalize_line_endings(view, string):
@@ -570,7 +591,9 @@ def get_metadata_regions(view, mode):
         if len(regions) > 0:
             region_begin = regions[0].begin()
             region_end = regions[len(regions) - 1].end()
-            result_region_list.append(sublime.Region(region_begin, region_end))
+            result_region_list.append(
+                sublime.Region(
+                    region_begin, region_end))
     elif mode == "multiple":
         for region in regions:
             result_region_list.append(region)
@@ -582,7 +605,8 @@ def get_metadata_regions(view, mode):
     return result_region_list
 
 
-def normalize_article_metadata_case(template_str, normalize_template_var=True):
+def normalize_article_metadata_case(
+        template_str, normalize_template_var=True):
     '''
     Markdown
 

--- a/Pelican.sublime-commands
+++ b/Pelican.sublime-commands
@@ -3,7 +3,7 @@
     { "caption": "Pelican: New Article (Markdown)", "command": "pelican_new_markdown" },
     { "caption": "Pelican: New Article (reStructuredText)", "command": "pelican_new_restructuredtext" },
     { "caption": "Pelican: Select Article Metadata", "command": "pelican_select_metadata" },
-    { "caption": "Pelican: Update Article Date", "command": "pelican_update_date" },
+    { "caption": "Pelican: Update Modified Date", "command": "pelican_update_modified_date" },
     { "caption": "Pelican: Update Slug using Title", "command": "pelican_generate_slug" },
     { "caption": "Pelican: Insert Category", "command": "pelican_insert_category" },
     { "caption": "Pelican: Insert Tag", "command": "pelican_insert_tag" }

--- a/Pelican.sublime-settings
+++ b/Pelican.sublime-settings
@@ -1,33 +1,81 @@
 {
-	"article_metadata_template": {
-    // Metadata template for Markdown articles, comments see in base.html file
+  // ===============
+  // Slug generation
+  // ===============
+
+  // By default, slug is not automatically generated if a slug has been
+  //   defined in the article.
+  // Set to `true` to force slug regeneration.
+  "force_slug_regeneration": false,
+
+  // Set to `"none"` to disable slug generation
+  // Set to `"title_change"` to generate slug when article title changes
+  //   Note that when set to `"title_change"`, slug will be regenerated
+  //     everytime you type in the title line, even if
+  //     `force_slug_regeneration` is set to `false`.
+  // Set to `"save"` to generate slug on save
+  //   If you want to force slug regeneration on each save, you have to set
+  //     `force_slug_regeneration` to `true`.
+  //   By default, slug is not automatically generated if a slug has been
+  //     defined in the article. This is to prevent unwanted slug change.
+  "generate_slug_from_title": "save",
+
+
+
+  // ==============================
+  // Customizable metadata template
+  // ==============================
+
+  // Metadata template for Markdown & reStructuredText articles.
+  "article_metadata_template": {
+    // Metadata template for Markdown articles
     "md":
       [
-        "Title: ",
-        "Template: ",
-        "Slug: ",
+        "Title: %(title)s",
+        "Slug: %(slug)s",
         "Date: %(date)s",
         "Modified: %(modified)s",
-        "Version: %(version)s",
+        "Tags: %(tags)s",
+        "Category: %(category)s",
         "Author: %(author)s",
         "Lang: %(lang)s",
-        "Summary: %(summary)s",
-        "PageTitle: %(pagetitle)s",
-		"MetaContent: %(metacontent)s",
-		"PageColors: %(pagecolors)s",
-		"IconLeftOrRight: %(iconleftorright)s",
-		"Tags: %(tags)s",
-        "Category: %(category)s",
-        "Noco: %(noco)s",
-		"Stylesheets: personal/",
-		"JavaScripts: personal/",
-        "JQuery: true",
-        "Mailhu: true",
-        "Fancybox: true",
-        "Rainbow: false",
-		"Tooltipster: false",
-		"ClipboardJs: false",
-		"DetailsPolyfill: false"
+        "Summary: %(summary)s"
+      ],
+
+    // Metadata template for reStructuredText articles
+    "rst":
+      [
+        ":title: %(title)s",
+        ":slug: %(slug)s",
+        ":date: %(date)s",
+        ":tags: %(tags)s",
+        ":category: %(category)s",
+        ":author: %(author)s",
+        ":lang: %(lang)s",
+        ":summary: %(summary)s"
       ]
-      }
+  },
+
+
+
+  // =====================================
+  // File Path Filter for Pelican Articles
+  // =====================================
+
+  // To prevent automatic slug generation from annoyly affecting other
+  //   Markdown/reStrcturedText files that are not Pelican articles,
+  //   SublimePelican processes only the Markdown/reStructuredText files
+  //   under `INPUTDIR` specified in the Makefile.
+
+  // When set to `false`, SublimePelican will use the regular expression
+  //   defined in `filepath_filter` as the file path filter for Pelican
+  //   articles.
+  "use_input_folder_in_makefile": true,
+
+  // File path filter for Pelican articles, written in a Python regular
+  //   expression.
+  // Effective only if `use_input_folder_in_makefile` is set to `false`.
+  // By default, only Markdown/reStructuredText files under `content/`
+  //   directory are deemed as Pelican article files.
+  "filepath_filter": "content/.*\\.(md|markdown|mkd|rst)$"
 }

--- a/Pelican.sublime-settings
+++ b/Pelican.sublime-settings
@@ -1,80 +1,33 @@
 {
-  // ===============
-  // Slug generation
-  // ===============
-
-  // By default, slug is not automatically generated if a slug has been
-  //   defined in the article.
-  // Set to `true` to force slug regeneration.
-  "force_slug_regeneration": false,
-
-  // Set to `"none"` to disable slug generation
-  // Set to `"title_change"` to generate slug when article title changes
-  //   Note that when set to `"title_change"`, slug will be regenerated
-  //     everytime you type in the title line, even if
-  //     `force_slug_regeneration` is set to `false`.
-  // Set to `"save"` to generate slug on save
-  //   If you want to force slug regeneration on each save, you have to set
-  //     `force_slug_regeneration` to `true`.
-  //   By default, slug is not automatically generated if a slug has been
-  //     defined in the article. This is to prevent unwanted slug change.
-  "generate_slug_from_title": "save",
-
-
-
-  // ==============================
-  // Customizable metadata template
-  // ==============================
-
-  // Metadata template for Markdown & reStructuredText articles.
-  "article_metadata_template": {
-    // Metadata template for Markdown articles
+	"article_metadata_template": {
+    // Metadata template for Markdown articles, comments see in base.html file
     "md":
       [
-        "Title: %(title)s",
-        "Slug: %(slug)s",
+        "Title: ",
+        "Template: ",
+        "Slug: ",
         "Date: %(date)s",
-        "Tags: %(tags)s",
-        "Category: %(category)s",
+        "Modified: %(modified)s",
+        "Version: %(version)s",
         "Author: %(author)s",
         "Lang: %(lang)s",
-        "Summary: %(summary)s"
-      ],
-
-    // Metadata template for reStructuredText articles
-    "rst":
-      [
-        ":title: %(title)s",
-        ":slug: %(slug)s",
-        ":date: %(date)s",
-        ":tags: %(tags)s",
-        ":category: %(category)s",
-        ":author: %(author)s",
-        ":lang: %(lang)s",
-        ":summary: %(summary)s"
+        "Summary: %(summary)s",
+        "PageTitle: %(pagetitle)s",
+		"MetaContent: %(metacontent)s",
+		"PageColors: %(pagecolors)s",
+		"IconLeftOrRight: %(iconleftorright)s",
+		"Tags: %(tags)s",
+        "Category: %(category)s",
+        "Noco: %(noco)s",
+		"Stylesheets: personal/",
+		"JavaScripts: personal/",
+        "JQuery: true",
+        "Mailhu: true",
+        "Fancybox: true",
+        "Rainbow: false",
+		"Tooltipster: false",
+		"ClipboardJs: false",
+		"DetailsPolyfill: false"
       ]
-  },
-
-
-
-  // =====================================
-  // File Path Filter for Pelican Articles
-  // =====================================
-
-  // To prevent automatic slug generation from annoyly affecting other
-  //   Markdown/reStrcturedText files that are not Pelican articles,
-  //   SublimePelican processes only the Markdown/reStructuredText files
-  //   under `INPUTDIR` specified in the Makefile.
-
-  // When set to `false`, SublimePelican will use the regular expression
-  //   defined in `filepath_filter` as the file path filter for Pelican
-  //   articles.
-  "use_input_folder_in_makefile": true,
-
-  // File path filter for Pelican articles, written in a Python regular
-  //   expression.
-  // Effective only if `use_input_folder_in_makefile` is set to `false`.
-  // By default, only Markdown/reStructuredText files under `content/`
-  //   directory are deemed as Pelican article files.
-  "filepath_filter": "content/.*\\.(md|markdown|mkd|rst)$"
+      }
 }

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Right click on a file being edit, and access the commands under the **SublimePel
     If you think it's hard to remember what tags you've used when writing articles, then this command is made for you.
     This command lists tags you've used in your Pelican site in the quick panel, allowing you to fuzzily select and insert a previously used tag quickly.
 
-*   **Pelican: Update Article Date**
+*   **Pelican: Update Modified Date**
 
     This command updates the date metadata field to current date and time.
 
@@ -123,6 +123,26 @@ Instead, customize your settings in **Preferences** > **Package Settings** > **S
         If you want to force slug regeneration on each save, you have to set `force_slug_regeneration` to `true`.
 
     Default value: `"save"`
+
+#### Modified date generation
+
+You can automatically update last modified date:
+
+![Update modified](http://i.imgur.com/L0po0FS.gif)
+
+Please, install [**Hooks**](https://packagecontrol.io/packages/Hooks) package → open any page/article in syntax, that you use for Pelican pages/articles → in Menu bar: `Preferences` → `Settings` - `Syntax Specific` → add in right-side file this lines:
+
+```json
+"on_pre_save_language": [{
+    "command": "pelican_update_modified_date"
+}],
+```
+
+Save file.
+
+Now if you run `save` command for saving your article or page, your modified date will update automatically.
+
+**Note**: command `pelican_update_modified_date` will run in all files for syntax, in which you write your pages and articles, if file contains `:?Modified:\s*` string.
 
 ### Customizable metadata template
 


### PR DESCRIPTION
### 1. Behavior before pull request

I create a new Markdown file → <kbd>Ctrl+Shift+P</kbd> (<kbd>⌘⇧p</kbd> for Mac) → `Pelican: Insert Metadata` → metadata insert:

![Date Metadata](http://i.imgur.com/1pBSdSi.png)

<kbd>Ctrl+Shift+P</kbd> (<kbd>⌘⇧p</kbd> for Mac) → `Pelican: Update Article Date` → `Date` metadata variable update:

![Update Date](http://i.imgur.com/1pBSdSi.png)

### 2. Behavior after pull request

I add a new metadata variable [**Modified**](http://docs.getpelican.com/en/stable/faq.html?highlight=Modified#can-i-use-arbitrary-metadata-in-my-templates).

I create a new Markdown file → <kbd>Ctrl+Shift+P</kbd> (<kbd>⌘⇧p</kbd> for Mac) → `Pelican: Insert Metadata` → metadata with new `Modified` variable insert, `Modified` value = `Date` value:

![Modified metadata](http://i.imgur.com/CEXEWGf.png)

<kbd>Ctrl+Shift+P</kbd> (<kbd>⌘⇧p</kbd> for Mac) → `Pelican: Update Modified` → `Modified` variable update, `Date` variable stay constantly.

![Update Modified](http://i.imgur.com/rIXGwQ7.png)

### 3. Argumentation

See [**@jachin arguments**](https://github.com/jsliang/sublime-pelican/issues/28). `Date` variable — time, when we create article or page. `Modified` variable — last update time article or page. We must update `Modified`, not `Date`. See [**File Metadata**](http://docs.getpelican.com/en/stable/content.html?highlight=Modified#file-metadata) section in official documentation.

### 4. Testing environment

**Operating system and version:**
Windows 10 Enterprise LTSB 64-bit EN
**Sublime Text:**
Build 3126
**Syntax:**
Markdown

### 5. Notes

1. I'm sorry, I don't know reStructuredText — I don't know, how my changes will work in `rst` files.
1. This pull request don't solve **#30** issue. `Modified` variable doesn't update by save.

Thanks.